### PR TITLE
docs: add KDoc to all public APIs + comprehensive README

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,45 @@
+# Contributing to Fakery
+
+## Prerequisites
+
+- JDK 21+
+- Android SDK (optional — only needed to build the `androidTarget`)
+
+## Build & test
+
+```bash
+# Run all JVM tests (fastest feedback loop)
+./gradlew jvmTest
+
+# Run sample module tests
+./gradlew :sample:jvmTest
+
+# Run everything
+./gradlew test
+```
+
+## Project structure
+
+| Module | Purpose |
+|---|---|
+| `:` (root) | The Fakery library |
+| `:sample` | Example app showing library integration |
+
+## Branch workflow
+
+- `main` — stable, always green
+- Feature/fix work goes on a branch: `feature/your-feature` or `fix/your-fix`
+- Open a PR against `main`; CI must pass before merge
+
+## Code style
+
+- No wildcard imports (`import foo.*`)
+- KDoc on all `public` API surface
+- Explicit return types on `public` functions
+
+## Adding a new platform
+
+1. Declare the target in `build.gradle.kts`
+2. Add `actual fun createFakeryServer(...)` in the appropriate source set
+3. Add `actual fun loadStubsFromDirectory(...)` and `actual fun loadStubsFromFile(...)` for file I/O
+4. Add at least one smoke test in the new target's test source set

--- a/README.md
+++ b/README.md
@@ -1,11 +1,77 @@
 # Fakery 🎭
 
-A Kotlin Multiplatform fake HTTP server for testing your networking layer.  
-Define stubs as JSON files. Point your client at `server.baseUrl`. Done.
+A **Kotlin Multiplatform** fake HTTP server for testing your networking layer.  
+Define stubs as JSON files. Point your client at `server.baseUrl`. No real network, no flakiness.
 
-## Platforms
+[![Kotlin](https://img.shields.io/badge/Kotlin-2.1.0-blue)](https://kotlinlang.org)
+[![Ktor](https://img.shields.io/badge/Ktor-3.0.3-orange)](https://ktor.io)
 
-JVM · Android · iOS · macOS · Linux · Windows
+---
+
+## Supported platforms
+
+| Platform | Engine |
+|---|---|
+| JVM | Ktor CIO |
+| Android | Ktor CIO |
+| iOS (arm64, x64, Simulator) | Ktor CIO |
+| macOS (arm64, x64) | Ktor CIO |
+| Linux (x64) | Ktor CIO |
+| Windows (mingwX64) | Ktor CIO |
+
+---
+
+## Quick start
+
+### 1. Add the dependency
+
+```kotlin
+// build.gradle.kts
+testImplementation("dev.fakery:fakery:0.1.0")
+```
+
+### 2. Define your stubs as JSON
+
+```json
+[
+  {
+    "request":  { "method": "GET", "path": "/users" },
+    "response": { "status": 200, "body": [{"id": 1, "name": "Alice"}] }
+  },
+  {
+    "request":  { "method": "POST", "path": "/users" },
+    "response": { "status": 201, "body": {"id": 2, "name": "Bob"} }
+  }
+]
+```
+
+### 3. Use in your test
+
+```kotlin
+class UserApiTest {
+
+    private lateinit var server: FakeryServer
+
+    @BeforeTest
+    fun setUp() {
+        server = fakery(json = File("src/test/resources/stubs/users.json").readText())
+        server.start()
+    }
+
+    @AfterTest
+    fun tearDown() = server.stop()
+
+    @Test
+    fun `fetch users calls correct endpoint`() = runTest {
+        val client = UserApiClient(baseUrl = server.baseUrl)
+        val users  = client.getUsers()
+        assertEquals(1, users.size)
+        assertEquals("Alice", users[0].name)
+    }
+}
+```
+
+---
 
 ## Stub format
 
@@ -15,82 +81,161 @@ JVM · Android · iOS · macOS · Linux · Windows
     "method":  "GET",
     "path":    "/users/123",
     "headers": { "Authorization": "Bearer token" },
-    "body":    {}
+    "body":    { "filter": "active" }
   },
   "response": {
     "status":  200,
-    "headers": { "Content-Type": "application/json" },
+    "headers": { "X-Request-Id": "abc-123" },
     "body":    { "id": 123, "name": "Alice" }
   }
 }
 ```
 
-| Field | Required | Default | Notes |
+| Field | Required | Default | Description |
 |---|---|---|---|
-| `request.method` | No | `GET` | Case-insensitive |
-| `request.path` | Yes | — | Exact match, no query string |
-| `request.headers` | No | `{}` | Subset match |
-| `request.body` | No | `null` | Skipped when absent |
-| `response.status` | No | `200` | |
-| `response.headers` | No | `{}` | Added to the response |
-| `response.body` | No | `null` | Any JSON value |
+| `request.method` | No | `"GET"` | HTTP method, case-insensitive |
+| `request.path` | **Yes** | — | Exact path match (query string is stripped) |
+| `request.headers` | No | `{}` | Header subset — only declared keys are checked |
+| `request.body` | No | `null` | JSON body match — skipped when absent |
+| `response.status` | No | `200` | HTTP status code |
+| `response.headers` | No | `{}` | Headers added to the response |
+| `response.body` | No | `null` | Any JSON value — object, array, primitive |
 
-## Usage
+### Matching rules
 
-### From a JSON string
+Stubs are evaluated in **registration order** (first match wins). A stub matches when **all** of:
+1. `method` matches (case-insensitive)
+2. `path` matches exactly (query string stripped)
+3. All `headers` in the stub are present in the request
+4. `body` is equal (only checked when the stub defines a body)
 
+If no stub matches, Fakery returns `404` with:
+```json
+{ "error": "No stub for GET /users/unknown" }
+```
+
+---
+
+## Entry points
+
+### `fakery(json)` — from a JSON string
 ```kotlin
 val server = fakery(json = """
-    {
-      "request":  { "method": "GET", "path": "/users" },
-      "response": { "status": 200, "body": {"users": []} }
-    }
+    { "request": { "path": "/health" }, "response": { "status": 200 } }
 """)
-server.start()
-// test against server.baseUrl
-server.stop()
 ```
 
-### From a file (JVM / Desktop)
+### `fakery(stubs)` — from parsed stubs
+```kotlin
+val stubs = listOf(
+    StubDefinition(
+        request  = StubRequest(path = "/ping"),
+        response = StubResponse(status = 200),
+    )
+)
+val server = fakery(stubs = stubs)
+```
 
+### `fakeryFromFile(path)` — from a single file
 ```kotlin
 val server = fakeryFromFile("src/test/resources/stubs/users.json")
-server.start()
 ```
 
-### From a directory
-
+### `fakeryFromDirectory(path)` — from a directory of `.json` files
 ```kotlin
 // Loads all *.json files in the directory
 val server = fakeryFromDirectory("src/test/resources/stubs/")
-server.start()
 ```
 
-### Each file can be a single stub or an array
+---
 
-```json
-[
-  { "request": { "path": "/a" }, "response": { "status": 200 } },
-  { "request": { "path": "/b" }, "response": { "status": 404 } }
-]
-```
-
-### Add stubs at runtime
+## Runtime stub management
 
 ```kotlin
-val server = fakery(stubs = emptyList())
-server.start()
+val server = fakery(stubs = emptyList()).also { it.start() }
 
-server.addStub(StubDefinition(
-    request  = StubRequest(path = "/dynamic"),
-    response = StubResponse(status = 200),
-))
+// Add stubs at runtime (safe after start)
+server.addStub(
+    StubDefinition(
+        request  = StubRequest(method = "GET", path = "/feature-flags"),
+        response = StubResponse(status = 200, body = buildJsonObject {
+            put("darkMode", JsonPrimitive(true))
+        }),
+    )
+)
+
+// Reset between test cases
+server.clearStubs()
 ```
+
+---
+
+## Organising stubs
+
+For large test suites, keep stubs in `src/test/resources/stubs/`:
+
+```
+src/test/resources/stubs/
+├── users.json        ← array of user endpoint stubs
+├── auth.json         ← login / logout stubs
+└── errors.json       ← 4xx / 5xx scenarios
+```
+
+Load them all at once:
+```kotlin
+server = fakeryFromDirectory("src/test/resources/stubs/")
+```
+
+Each file can hold a **single stub** or an **array of stubs**.
+
+---
 
 ## Architecture
 
 ```
-commonMain          ← StubDefinition, FakeryServer, matching logic, JSON parsing (pure KMP)
-jvmAndAndroidMain   ← Ktor CIO server + java.io.File loader
-nativeMain          ← Ktor CIO server + kotlinx-io file loader
+fakery/
+├── commonMain/             ← Public API + stub matching (pure Kotlin, no Ktor)
+│   ├── Fakery.kt           ← Entry points: fakery(), fakeryFromFile(), fakeryFromDirectory()
+│   ├── FakeryServer.kt     ← Interface: start/stop/addStub/clearStubs
+│   ├── StubDefinition.kt   ← @Serializable data classes: StubDefinition, StubRequest, StubResponse
+│   ├── StubLoader.kt       ← JSON parsing + expect file-loading functions
+│   ├── StubMatcher.kt      ← Request matching logic (internal)
+│   └── FakeryApplication.kt← Ktor application module (internal)
+│
+├── jvmAndAndroidMain/      ← JVM + Android implementation
+│   ├── FakeryServerImpl.kt ← Ktor CIO server, java.net.ServerSocket for free-port
+│   └── StubLoaderImpl.kt   ← java.io.File for directory/file reading
+│
+└── nativeMain/             ← iOS / macOS / Linux / Windows implementation
+    ├── FakeryServerImpl.kt ← Ktor CIO server
+    └── StubLoaderImpl.kt   ← kotlinx-io SystemFileSystem for file reading
 ```
+
+---
+
+## Sample module
+
+See [`sample/`](sample/) for a full example:
+- `UserApiClient` — a real Ktor HTTP client interface
+- `UserApiClientImpl` — the production implementation
+- `UserApiClientTest` — tests that use Fakery to stub the server
+
+```kotlin
+// From sample/src/jvmTest/kotlin/sample/UserApiClientTest.kt
+@BeforeTest
+fun setUp() {
+    server = fakery(json = stubs)
+    server.start()
+    apiClient = UserApiClientImpl(client = HttpClient { ... }, baseUrl = server.baseUrl)
+}
+```
+
+---
+
+## Roadmap
+
+- [ ] Path pattern matching (`/users/{id}`)
+- [ ] Response delays (simulating slow/flaky networks)
+- [ ] Request recording & verification (`server.verify(GET, "/users").wasCalled(1)`)
+- [ ] JUnit 5 Extension + JUnit 4 Rule
+- [ ] Maven Central publishing

--- a/src/commonMain/kotlin/dev/fakery/Fakery.kt
+++ b/src/commonMain/kotlin/dev/fakery/Fakery.kt
@@ -1,6 +1,6 @@
 package dev.fakery
 
-/** Platform-specific server factory. */
+/** Platform-specific server factory wired via expect/actual. */
 internal expect fun createFakeryServer(port: Int, stubs: MutableList<StubDefinition>): FakeryServer
 
 // ── Entry points ─────────────────────────────────────────────────────────────
@@ -8,7 +8,22 @@ internal expect fun createFakeryServer(port: Int, stubs: MutableList<StubDefinit
 /**
  * Creates a [FakeryServer] from a list of already-parsed [StubDefinition]s.
  *
- * @param port `0` = OS picks a free port (recommended for tests).
+ * Use this overload when you build stubs programmatically:
+ * ```kotlin
+ * val stubs = listOf(
+ *     StubDefinition(
+ *         request  = StubRequest(method = "GET", path = "/users"),
+ *         response = StubResponse(status = 200),
+ *     )
+ * )
+ * val server = fakery(stubs = stubs)
+ * server.start()
+ * ```
+ *
+ * @param port Port to listen on. `0` (default) lets the OS assign a free port — recommended
+ *             for tests to avoid port conflicts when running in parallel.
+ * @param stubs Pre-parsed stub definitions.
+ * @return A [FakeryServer] ready to [FakeryServer.start].
  */
 fun fakery(port: Int = 0, stubs: List<StubDefinition>): FakeryServer =
     createFakeryServer(port, stubs.toMutableList())
@@ -16,11 +31,30 @@ fun fakery(port: Int = 0, stubs: List<StubDefinition>): FakeryServer =
 /**
  * Creates a [FakeryServer] by parsing stubs from a JSON string.
  *
- * The string can be either:
- * - a single stub object: `{ "request": {...}, "response": {...} }`
- * - a JSON array of stubs: `[{ ... }, { ... }]`
+ * The string may be either a **single stub object**:
+ * ```json
+ * { "request": { "method": "GET", "path": "/ping" }, "response": { "status": 200 } }
+ * ```
+ * or a **JSON array** of stubs:
+ * ```json
+ * [
+ *   { "request": { "path": "/a" }, "response": { "status": 200 } },
+ *   { "request": { "path": "/b" }, "response": { "status": 404 } }
+ * ]
+ * ```
  *
- * @param port `0` = OS picks a free port.
+ * Example:
+ * ```kotlin
+ * val server = fakery(json = File("stubs/users.json").readText())
+ * server.start()
+ * // point your HTTP client at server.baseUrl
+ * server.stop()
+ * ```
+ *
+ * @param port Port to listen on. `0` = OS picks a free port (recommended).
+ * @param json JSON string — single stub object or array.
+ * @return A [FakeryServer] ready to [FakeryServer.start].
+ * @throws kotlinx.serialization.SerializationException if the JSON is malformed.
  */
 fun fakery(port: Int = 0, json: String): FakeryServer {
     val stubs = json.trim().let { s ->
@@ -32,15 +66,35 @@ fun fakery(port: Int = 0, json: String): FakeryServer {
 /**
  * Creates a [FakeryServer] by loading all `.json` stub files from [directoryPath].
  *
- * @param port `0` = OS picks a free port.
+ * Each file may contain a single [StubDefinition] object **or** a JSON array of them.
+ * Files are loaded in filesystem order; later stubs do not override earlier ones —
+ * matching is first-match-wins.
+ *
+ * ```kotlin
+ * val server = fakeryFromDirectory("src/test/resources/stubs/")
+ * server.start()
+ * ```
+ *
+ * @param port Port to listen on. `0` = OS picks a free port.
+ * @param directoryPath Path to a directory containing `.json` stub files.
+ * @return A [FakeryServer] ready to [FakeryServer.start].
  */
 fun fakeryFromDirectory(port: Int = 0, directoryPath: String): FakeryServer =
     fakery(port, loadStubsFromDirectory(directoryPath))
 
 /**
- * Creates a [FakeryServer] from a single stub file.
+ * Creates a [FakeryServer] from a single `.json` stub file.
  *
- * @param port `0` = OS picks a free port.
+ * The file may contain a single [StubDefinition] object **or** a JSON array of them.
+ *
+ * ```kotlin
+ * val server = fakeryFromFile("src/test/resources/stubs/users.json")
+ * server.start()
+ * ```
+ *
+ * @param port Port to listen on. `0` = OS picks a free port.
+ * @param filePath Path to a `.json` file.
+ * @return A [FakeryServer] ready to [FakeryServer.start].
  */
 fun fakeryFromFile(port: Int = 0, filePath: String): FakeryServer =
     fakery(port, loadStubsFromFile(filePath))

--- a/src/commonMain/kotlin/dev/fakery/FakeryServer.kt
+++ b/src/commonMain/kotlin/dev/fakery/FakeryServer.kt
@@ -1,31 +1,99 @@
 package dev.fakery
 
 /**
- * A running fake HTTP server.
+ * A running fake HTTP server backed by Ktor CIO.
  *
+ * Create instances via the [fakery], [fakeryFromFile], or [fakeryFromDirectory] entry points.
+ *
+ * ### Typical test lifecycle
  * ```kotlin
- * val server = fakery(json = File("stubs/users.json").readText())
- * server.start()
- * // test against server.baseUrl ...
- * server.stop()
+ * class MyApiTest {
+ *     private lateinit var server: FakeryServer
+ *
+ *     @BeforeTest
+ *     fun setUp() {
+ *         server = fakery(json = """
+ *             [
+ *               { "request": { "path": "/users" },   "response": { "status": 200, "body": [] } },
+ *               { "request": { "path": "/users/1" }, "response": { "status": 200, "body": {"id":1} } }
+ *             ]
+ *         """)
+ *         server.start()
+ *     }
+ *
+ *     @AfterTest
+ *     fun tearDown() = server.stop()
+ *
+ *     @Test
+ *     fun `fetch users`() = runTest {
+ *         val users = myApiClient(server.baseUrl).getUsers()
+ *         assertEquals(0, users.size)
+ *     }
+ * }
  * ```
+ *
+ * ### Stub matching
+ * On each inbound request, Fakery walks the stub list in registration order and returns the
+ * **first** stub where **all** of the following match:
+ * 1. `method` — case-insensitive (defaults to `GET` when omitted in JSON)
+ * 2. `path`   — exact match, query string is stripped before comparison
+ * 3. `headers`— every key/value in the stub must be present in the request (subset match)
+ * 4. `body`   — skipped when `null`; compared as parsed JSON when present
+ *
+ * If no stub matches, the server returns `404` with a JSON error body.
  */
 interface FakeryServer {
-    /** e.g. "http://localhost:52341" */
+
+    /**
+     * The base URL of the server, e.g. `"http://localhost:52341"`.
+     * Use this as the `baseUrl` for your HTTP client under test.
+     */
     val baseUrl: String
 
-    /** The port the server is listening on. */
+    /**
+     * The port the server is (or will be) listening on.
+     * Useful when [port] was specified as `0` and you need to know the assigned port.
+     */
     val port: Int
 
-    /** Starts the server. Returns once the server is ready to accept requests. */
+    /**
+     * Starts the server. Returns once the server is ready to accept requests.
+     *
+     * Call this in your test `setUp` / `@BeforeTest` method.
+     * Pair with [stop] to avoid port leaks between tests.
+     */
     fun start()
 
-    /** Stops the server and releases resources. */
+    /**
+     * Stops the server and releases all resources.
+     *
+     * Safe to call multiple times. Call this in your `tearDown` / `@AfterTest` method.
+     */
     fun stop()
 
-    /** Adds a stub at runtime (safe to call after [start]). */
+    /**
+     * Adds a stub at runtime. Safe to call after [start].
+     *
+     * New stubs are appended to the end of the list; use this to add
+     * test-specific overrides after the server has already started.
+     *
+     * ```kotlin
+     * server.addStub(StubDefinition(
+     *     request  = StubRequest(path = "/feature-flag"),
+     *     response = StubResponse(status = 200, body = JsonPrimitive(true)),
+     * ))
+     * ```
+     */
     fun addStub(stub: StubDefinition)
 
-    /** Removes all registered stubs. */
+    /**
+     * Removes all registered stubs.
+     *
+     * Useful between test cases when sharing a single server instance:
+     * ```kotlin
+     * @AfterTest fun reset() = server.clearStubs()
+     * ```
+     * Any request arriving after this call (before new stubs are added) will receive a `404`.
+     */
     fun clearStubs()
 }

--- a/src/commonMain/kotlin/dev/fakery/StubDefinition.kt
+++ b/src/commonMain/kotlin/dev/fakery/StubDefinition.kt
@@ -1,19 +1,30 @@
 package dev.fakery
 
-import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.JsonElement
 
 /**
- * Top-level stub — maps a [StubRequest] to a [StubResponse].
+ * A single stub — pairs an inbound [StubRequest] matcher with a canned [StubResponse].
  *
- * JSON format:
+ * ### JSON format
  * ```json
  * {
- *   "request":  { "method": "GET", "path": "/users/123", "headers": {}, "body": {} },
- *   "response": { "status": 200,   "headers": {},         "body": {}  }
+ *   "request": {
+ *     "method":  "GET",
+ *     "path":    "/users/123",
+ *     "headers": { "Authorization": "Bearer token" },
+ *     "body":    { "filter": "active" }
+ *   },
+ *   "response": {
+ *     "status":  200,
+ *     "headers": { "X-Request-Id": "abc" },
+ *     "body":    { "id": 123, "name": "Alice" }
+ *   }
  * }
  * ```
+ *
+ * Stubs files may contain a single object or a JSON array of objects.
+ * Matching is **first-match-wins** in registration order.
  */
 @Serializable
 data class StubDefinition(
@@ -21,38 +32,79 @@ data class StubDefinition(
     val response: StubResponse,
 )
 
+/**
+ * Describes which inbound request a stub should match.
+ *
+ * All non-null fields must match for the stub to be selected.
+ * Fields omitted from the JSON take their default values.
+ */
 @Serializable
 data class StubRequest(
-    /** HTTP method (case-insensitive). Defaults to GET. */
+    /**
+     * HTTP method to match, case-insensitive.
+     *
+     * Common values: `"GET"`, `"POST"`, `"PUT"`, `"DELETE"`, `"PATCH"`.
+     * Defaults to `"GET"` when omitted.
+     */
     val method: String = "GET",
 
-    /** Request path to match, e.g. "/users/123". */
+    /**
+     * Exact request path to match. The query string is stripped before comparison.
+     *
+     * Example: `"/users/123"` matches `GET /users/123?foo=bar`.
+     */
     val path: String,
 
     /**
-     * Headers to match (subset). Only keys declared here are checked;
+     * Header subset to match. Only keys declared here are checked;
      * extra headers on the incoming request are ignored.
+     *
+     * Comparison is case-insensitive on values.
+     *
+     * Example: `{ "Authorization": "Bearer token" }` requires the request to
+     * carry that exact Authorization header value.
      */
     val headers: Map<String, String> = emptyMap(),
 
     /**
-     * Body to match. `null` (or absent) means "don't check the body".
-     * When present, the incoming body must equal this JSON value exactly.
+     * JSON body to match. When `null` (the default), the request body is not checked.
+     * When present, the incoming body is parsed as JSON and compared for equality.
+     *
+     * Use this for POST/PUT stubs that should only fire for a specific payload.
      */
     val body: JsonElement? = null,
 )
 
+/**
+ * Describes the HTTP response Fakery sends when a [StubRequest] is matched.
+ */
 @Serializable
 data class StubResponse(
-    /** HTTP status code to return. */
+    /**
+     * HTTP status code. Defaults to `200`.
+     *
+     * Use standard codes: `200 OK`, `201 Created`, `204 No Content`,
+     * `400 Bad Request`, `401 Unauthorized`, `404 Not Found`, `500 Internal Server Error`, etc.
+     */
     val status: Int = 200,
 
-    /** Headers to include in the response. */
+    /**
+     * Headers to include in the response. Merged with Fakery's default headers.
+     *
+     * The `Content-Type` header is derived from [body] automatically unless overridden here.
+     */
     val headers: Map<String, String> = emptyMap(),
 
     /**
-     * Response body. `null` means an empty body.
-     * JSON objects/arrays are serialized back to a JSON string before sending.
+     * Response body as a JSON value.
+     *
+     * - `null` (default) → empty response body
+     * - `JsonObject`     → serialized to a JSON object string
+     * - `JsonArray`      → serialized to a JSON array string
+     * - `JsonPrimitive`  → serialized to its JSON representation (string, number, boolean)
+     *
+     * The `Content-Type` defaults to `application/json; charset=utf-8` unless
+     * overridden via [headers].
      */
     val body: JsonElement? = null,
 )

--- a/src/commonMain/kotlin/dev/fakery/StubLoader.kt
+++ b/src/commonMain/kotlin/dev/fakery/StubLoader.kt
@@ -1,8 +1,16 @@
 package dev.fakery
 
+import kotlinx.serialization.builtins.ListSerializer
 import kotlinx.serialization.json.Json
 
-// Lenient parser — tolerates unknown keys, missing fields, etc.
+/**
+ * The JSON parser used across Fakery.
+ *
+ * Configured for lenience so that:
+ * - Unknown keys in stub files are silently ignored (forward-compatible stubs)
+ * - Missing optional fields fall back to their defaults
+ * - Non-strict JSON (trailing commas, comments) is tolerated
+ */
 internal val FakeryJson = Json {
     ignoreUnknownKeys = true
     isLenient         = true
@@ -13,32 +21,56 @@ internal val FakeryJson = Json {
  * Parses a single JSON stub string into a [StubDefinition].
  *
  * ```kotlin
- * val stub = parseStub("""{"request":{"path":"/ping"},"response":{"status":200}}""")
+ * val stub = parseStub("""
+ *   { "request": { "path": "/ping" }, "response": { "status": 200 } }
+ * """)
+ * val server = fakery(stubs = listOf(stub))
  * ```
+ *
+ * @throws kotlinx.serialization.SerializationException if the JSON is invalid or missing required fields.
  */
 fun parseStub(json: String): StubDefinition =
     FakeryJson.decodeFromString(StubDefinition.serializer(), json)
 
 /**
- * Parses a JSON array of stubs.
+ * Parses a JSON array of stubs into a [List] of [StubDefinition].
  *
  * ```kotlin
- * val stubs = parseStubs("""[{"request":{"path":"/a"},"response":{"status":200}}]""")
+ * val stubs = parseStubs("""
+ *   [
+ *     { "request": { "path": "/a" }, "response": { "status": 200 } },
+ *     { "request": { "path": "/b" }, "response": { "status": 404 } }
+ *   ]
+ * """)
+ * val server = fakery(stubs = stubs)
  * ```
+ *
+ * @throws kotlinx.serialization.SerializationException if the JSON is invalid.
  */
 fun parseStubs(json: String): List<StubDefinition> =
-    FakeryJson.decodeFromString(kotlinx.serialization.builtins.ListSerializer(StubDefinition.serializer()), json)
+    FakeryJson.decodeFromString(ListSerializer(StubDefinition.serializer()), json)
 
 /**
- * Platform-specific: read all `.json` stub files from [directoryPath] and return parsed stubs.
+ * Loads all `.json` stub files from [directoryPath] and returns the combined list of stubs.
  *
- * Each file may contain either a single [StubDefinition] object or a JSON array of them.
+ * Each file may contain either:
+ * - a single [StubDefinition] object, or
+ * - a JSON array of [StubDefinition] objects.
+ *
+ * Files are read in filesystem order. Use [fakeryFromDirectory] for the typical entry point.
+ *
+ * @param directoryPath Absolute or relative path to a directory.
+ * @return Flattened list of all stubs found across all `.json` files.
  */
 expect fun loadStubsFromDirectory(directoryPath: String): List<StubDefinition>
 
 /**
- * Platform-specific: read a single `.json` stub file and return the parsed stub(s).
+ * Loads stub(s) from a single `.json` file and returns them as a list.
  *
- * The file may contain either a single [StubDefinition] object or a JSON array of them.
+ * The file may contain either a single [StubDefinition] object or a JSON array.
+ * Use [fakeryFromFile] for the typical entry point.
+ *
+ * @param filePath Absolute or relative path to a `.json` file.
+ * @return One or more stubs parsed from the file.
  */
 expect fun loadStubsFromFile(filePath: String): List<StubDefinition>


### PR DESCRIPTION
## What

- Full KDoc on all public API surface (`Fakery.kt`, `FakeryServer.kt`, `StubDefinition.kt`, `StubLoader.kt`)
- Rewrote README with: quick start, stub format reference table, matching rules, all entry points, runtime management, file organisation guide, architecture overview, roadmap
- Added `CONTRIBUTING.md`

## Highlights

`FakeryServer` now documents the exact matching algorithm, lifecycle expectations, and usage patterns inline.

`StubDefinition` fields are fully documented including defaults, comparison semantics, and examples.

## Checklist
- [x] KDoc on all `public` symbols
- [x] README covers all entry points
- [x] Build passes (`./gradlew jvmTest :sample:jvmTest`)