### PR TITLE
feat: standalone server JAR + recursive sorted stub loading

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,6 +6,7 @@ coroutines   = "1.9.0"
 serialization = "1.7.3"
 kotlinx-io   = "0.3.0"
 atomicfu     = "0.25.0"
+shadow       = "8.3.5"
 
 [libraries]
 ktor-server-core    = { module = "io.ktor:ktor-server-core",       version.ref = "ktor" }
@@ -25,3 +26,5 @@ atomicfu            = { module = "org.jetbrains.kotlinx:atomicfu",            ve
 kotlin-multiplatform  = { id = "org.jetbrains.kotlin.multiplatform",       version.ref = "kotlin" }
 kotlin-serialization  = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 android-library       = { id = "com.android.library",                       version.ref = "agp" }
+kotlin-jvm            = { id = "org.jetbrains.kotlin.jvm",                   version.ref = "kotlin" }
+shadow                = { id = "com.gradleup.shadow",                        version.ref = "shadow" }

--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -1,0 +1,23 @@
+plugins {
+    kotlin("jvm")                  // version already resolved by root KMP plugin
+    alias(libs.plugins.shadow)
+    application
+}
+
+group   = "dev.anvith.fakery"
+version = "0.1.0"
+
+application {
+    mainClass.set("dev.anvith.fakery.server.MainKt")
+}
+
+dependencies {
+    implementation(project(":"))
+}
+
+// The shadow JAR is the primary artifact; disable the plain jar task to avoid confusion.
+tasks.jar { enabled = false }
+tasks.shadowJar {
+    archiveBaseName.set("fakery-server")
+    archiveClassifier.set("")
+}

--- a/server/src/main/kotlin/dev/anvith/fakery/server/Main.kt
+++ b/server/src/main/kotlin/dev/anvith/fakery/server/Main.kt
@@ -1,0 +1,70 @@
+package dev.anvith.fakery.server
+
+import dev.anvith.fakery.fakeryFromDirectory
+
+/**
+ * Fakery standalone server — loads stubs from a directory and serves them over HTTP.
+ *
+ * Usage:
+ * ```
+ * java -jar fakery-server.jar --directory <path> [--port <port>]
+ * ```
+ *
+ * Options:
+ *   --directory  Path to a directory containing `.json` stub files (required).
+ *                Subdirectories are walked recursively. Files are loaded in
+ *                alphabetical order of their fully-qualified name, where path
+ *                separators are replaced by underscores:
+ *                `auth/login.json` → sorts as `auth_login.json`.
+ *
+ *   --port       Port to listen on (optional, defaults to 8080).
+ *                Pass 0 to let the OS pick a free port.
+ */
+fun main(args: Array<String>) {
+    val argMap = parseArgs(args)
+
+    val directory = argMap["--directory"] ?: run {
+        System.err.println("Error: --directory <path> is required.")
+        System.err.println()
+        System.err.println("Usage: fakery-server --directory <path> [--port <port>]")
+        System.exit(1)
+        return
+    }
+
+    val port = argMap["--port"]?.toIntOrNull() ?: 8080
+
+    val server = fakeryFromDirectory(port = port, directoryPath = directory)
+    server.start()
+
+    println("┌─────────────────────────────────────────┐")
+    println("│           Fakery Standalone Server       │")
+    println("├─────────────────────────────────────────┤")
+    println("│  Listening on : ${server.baseUrl.padEnd(24)}│")
+    println("│  Stubs from   : ${directory.take(24).padEnd(24)}│")
+    println("│  Press Ctrl+C to stop                   │")
+    println("└─────────────────────────────────────────┘")
+
+    Runtime.getRuntime().addShutdownHook(Thread {
+        println("\nShutting down Fakery server...")
+        server.stop()
+    })
+
+    // Block the main thread until the process is killed.
+    Thread.currentThread().join()
+}
+
+/** Parses `--key value` pairs from [args], ignoring bare flags with no following value. */
+private fun parseArgs(args: Array<String>): Map<String, String> {
+    val result = mutableMapOf<String, String>()
+    var i = 0
+    while (i < args.size) {
+        val key = args[i]
+        if (key.startsWith("--") && i + 1 < args.size && !args[i + 1].startsWith("--")) {
+            result[key] = args[i + 1]
+            i += 2
+        } else {
+            i++
+        }
+    }
+    return result
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -16,3 +16,4 @@ dependencyResolutionManagement {
 }
 
 include(":sample")
+include(":server")

--- a/src/jvmAndAndroidMain/kotlin/dev/anvith/fakery/StubLoaderImpl.kt
+++ b/src/jvmAndAndroidMain/kotlin/dev/anvith/fakery/StubLoaderImpl.kt
@@ -2,11 +2,18 @@ package dev.anvith.fakery
 
 import java.io.File
 
-actual fun loadStubsFromDirectory(directoryPath: String): List<StubDefinition> =
-    File(directoryPath)
-        .listFiles { f -> f.isFile && f.extension == "json" }
-        ?.flatMap { loadStubsFromFile(it.absolutePath) }
-        ?: emptyList()
+actual fun loadStubsFromDirectory(directoryPath: String): List<StubDefinition> {
+    val root = File(directoryPath)
+    return root.walkTopDown()
+        .filter { it.isFile && it.extension == "json" }
+        .sortedBy { file ->
+            // Sort key: relative path from root with OS separator replaced by '_'.
+            // e.g. root=stubs/, file=stubs/auth/login.json → sort key "auth_login.json"
+            file.relativeTo(root).path.replace(File.separatorChar, '_')
+        }
+        .flatMap { loadStubsFromFile(it.absolutePath) }
+        .toList()
+}
 
 actual fun loadStubsFromFile(filePath: String): List<StubDefinition> {
     val content = File(filePath).readText()

--- a/src/nativeMain/kotlin/dev/anvith/fakery/StubLoaderImpl.kt
+++ b/src/nativeMain/kotlin/dev/anvith/fakery/StubLoaderImpl.kt
@@ -6,10 +6,10 @@ import kotlinx.io.files.SystemFileSystem
 import kotlinx.io.readString
 
 actual fun loadStubsFromDirectory(directoryPath: String): List<StubDefinition> {
-    val dir = Path(directoryPath)
-    return SystemFileSystem.list(dir)
-        .filter { it.name.endsWith(".json") }
-        .flatMap { loadStubsFromFile(it.toString()) }
+    val root = Path(directoryPath)
+    return collectJsonFiles(root, root)
+        .sortedBy { (sortKey, _) -> sortKey }
+        .flatMap { (_, path) -> loadStubsFromFile(path.toString()) }
 }
 
 actual fun loadStubsFromFile(filePath: String): List<StubDefinition> {
@@ -17,4 +17,29 @@ actual fun loadStubsFromFile(filePath: String): List<StubDefinition> {
     return content.trim().let { s ->
         if (s.startsWith("[")) parseStubs(s) else listOf(parseStub(s))
     }
+}
+
+/**
+ * Recursively collects all `.json` files under [dir], paired with their sort key.
+ *
+ * The sort key is the path relative to [root] with directory separators replaced by `_`,
+ * so `auth/login.json` → `auth_login.json` and `users/list.json` → `users_list.json`.
+ * This produces deterministic alphabetical ordering across nested directories.
+ */
+private fun collectJsonFiles(dir: Path, root: Path): List<Pair<String, Path>> {
+    val result = mutableListOf<Pair<String, Path>>()
+    for (child in SystemFileSystem.list(dir)) {
+        val metadata = SystemFileSystem.metadataOrNull(child) ?: continue
+        if (metadata.isDirectory) {
+            result += collectJsonFiles(child, root)
+        } else if (child.name.endsWith(".json")) {
+            val sortKey = child.toString()
+                .removePrefix(root.toString())
+                .trimStart('/', '\\')
+                .replace('/', '_')
+                .replace('\\', '_')
+            result.add(sortKey to child)
+        }
+    }
+    return result
 }


### PR DESCRIPTION
## Standalone server

A new `server` submodule produces a self-contained fat JAR:

```sh
java -jar fakery-server.jar --directory ./stubs --port 8080
```

The server loads all `.json` stubs from the directory, starts listening, and blocks until Ctrl+C. A shutdown hook calls `server.stop()` on exit.

## Recursive directory loading

`fakeryFromDirectory` now walks subdirectories recursively (previously only top-level files were scanned).

## Deterministic sort order

Files are sorted by their **fully-qualified name**: relative path from the root with directory separators replaced by `_`:

```
auth/login.json    → auth_login.json
users/list.json    → users_list.json
ping.json          → ping.json
```

Alphabetical sort on this key gives a consistent, predictable stub registration order regardless of filesystem or OS.

## Build changes

- `com.gradleup.shadow 8.3.5` added to version catalog
- `server/` included in `settings.gradle.kts`
- Fat JAR output: `server/build/libs/fakery-server-{version}.jar` (~10 MB)